### PR TITLE
Switch to using a view instead of a webhook to improve security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 {% if installed %}
-
+**BREAKING CHANGE: If you have previously setup this automation, the options required in your configuration have changed. Remove the existing configuration and update your configuration as defined in step 2 of the Installation>Configuring HomeAssistant section below. Note that the `Event notification endpoint URL` in step 11 of the `Installation>Set up your Zoom app` section has changed as well and will need to be updated.**
 **BREAKING CHANGE: If you have previously created webhook automations, you will need to update them to be event automations using the `zoom_automation_webhook` event. The latest update will not work properly without this change.**
 
 {% endif %}
@@ -16,6 +16,7 @@
 
 {% if installed %}
 
+**BREAKING CHANGE: If you have previously setup this automation, the options required in your configuration have changed. Remove the existing configuration and update your configuration as defined in step 2 of the Installation>Configuring HomeAssistant section below. Note that the `Event notification endpoint URL` in step 10 of the `Installation>Set up your Zoom app` has changed as well and will need to be updated.**
 **BREAKING CHANGE: If you have previously created webhook automations, you will need to update them to be event automations using the `zoom_automation_webhook` event. The latest update will not work properly without this change.**
 
 {% endif %}
@@ -62,13 +63,14 @@ You will get two sensors out of the box:
 5. Enter the following `Redirect URL for OAuth`: `<BASE_HA_URL>/auth/external/callback` (replace `<BASE_HA_URL>` with the URL you use to access Home Assistant, e.g. `https://ha.example.com`)
 6. Enter your `<BASE_HA_URL>` in the `Whitelist URL` section, then hit `Continue`.
 7. The `App Name` should already be filled out. A `Short Description` and `Long Description` are required, but since this app is only for you, it doesn't matter what you enter here. Click `Continue` once you are done.
-8. Enable `Event Subscriptions` and click on `Add new event subscriptions`.
-9. Enter a name for this subscription (does not matter).
-10. Your `Event notification endpoint URL` should be set to `<BASE_HA_URL>/api/webhook/<WEBHOOK_ID>`. Use any ID that you already aren't using in your Home Assistant instance. I generated mine using a [GUID Generator](https://www.guidgenerator.com/). Remember this ID for later.
-11. Now click on `Add events`. From this menu, you can choose what events you want to subscribe to. To use the `binary_sensor` provided by the integration, you would go to the `User Activity` event type and check the box next to `User's presence status has been updated`. If you want to get more details about when you start a meeting, add `Start Meeting` under `Meeting`.
-12. Once you are done, click `Done`, then `Save` the subscription before hitting `Continue`.
-13. The `Scopes` section should already be updated to the permissions the app would need for the events you selected earlier. Click `Continue`.
-14. You are now ready to configure Home Assistant!
+8. Make note of the `Verification Token` on the `Feature` page as you will need it for your configuration later.
+9. Enable `Event Subscriptions` and click on `Add new event subscriptions`.
+10. Enter a name for this subscription (does not matter).
+11. Your `Event notification endpoint URL` should be set to `<BASE_HA_URL>/api/zoom_automation`.
+12. Now click on `Add events`. From this menu, you can choose what events you want to subscribe to. To use the `binary_sensor` provided by the integration, you would go to the `User Activity` event type and check the box next to `User's presence status has been updated`. If you want to get more details about when you start a meeting, add `Start Meeting` under `Meeting`.
+13. Once you are done, click `Done`, then `Save` the subscription before hitting `Continue`.
+14. The `Scopes` section should already be updated to the permissions the app would need for the events you selected earlier. Click `Continue`.
+15. You are now ready to configure Home Assistant!
 
 ### Configure HomeAssistant
 
@@ -89,7 +91,7 @@ You can either do the initial setup through the UI or in your `configuration.yam
 zoom_automation:
     client_id: <CLIENT_ID_FROM_YOUR_CUSTOM_ZOOM_APP>
     client_secret: <CLIENT_ID_FROM_YOUR_CUSTOM_ZOOM_APP>
-    webhook_id: <WEBHOOK_ID_FROM_THE_EVENT_SUBSCRIPTIONS_PAGE_OF_SETTING_UP_YOUR_CUSTOM_ZOOM_APP>
+    verification_token: <VERIFICATION_TOKEN_FROM_THE_FEATURE_PAGE_OF_YOUR_CUSTOM_ZOOM_APP>
 ```
 3. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Zoom Automation". Select it.
 4. Skip to "Finish Setup" section below

--- a/custom_components/zoom_automation/__init__.py
+++ b/custom_components/zoom_automation/__init__.py
@@ -76,10 +76,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zoom from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     try:
-        implementation = (
-            await config_entry_oauth2_flow.async_get_config_entry_implementation(
-                hass, entry
-            )
+        implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
+            hass, entry
         )
     except ValueError:
         implementation = ZoomOAuth2Implementation(

--- a/custom_components/zoom_automation/__init__.py
+++ b/custom_components/zoom_automation/__init__.py
@@ -54,8 +54,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zoom from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     try:
-        implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
     except ValueError:
         implementation = ZoomOAuth2Implementation(

--- a/custom_components/zoom_automation/__init__.py
+++ b/custom_components/zoom_automation/__init__.py
@@ -76,8 +76,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zoom from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     try:
-        implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
     except ValueError:
         implementation = ZoomOAuth2Implementation(

--- a/custom_components/zoom_automation/__init__.py
+++ b/custom_components/zoom_automation/__init__.py
@@ -1,30 +1,21 @@
 """The Zoom Automation integration."""
-import json
 from logging import getLogger
 
-from aiohttp.web import Request
-from homeassistant.components.webhook import async_register, async_unregister
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_CLIENT_SECRET,
-    CONF_NAME,
-    CONF_WEBHOOK_ID,
-)
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .api import ZoomAPI
-from .common import ZoomOAuth2Implementation
+from .common import ZoomOAuth2Implementation, ZoomWebhookRequestView
 from .config_flow import OAuth2FlowHandler
 from .const import (
+    CONF_VERIFICATION_TOKEN,
     DOMAIN,
-    HA_CONNECTIVITY_EVENT,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
-    WEBHOOK_RESPONSE_SCHEMA,
     ZOOM_SCHEMA,
 )
 
@@ -51,7 +42,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
             config[DOMAIN][CONF_CLIENT_SECRET],
             OAUTH2_AUTHORIZE,
             OAUTH2_TOKEN,
-            config[DOMAIN][CONF_WEBHOOK_ID],
+            config[DOMAIN][CONF_VERIFICATION_TOKEN],
         ),
     )
     hass.data[DOMAIN][SOURCE_IMPORT] = True
@@ -59,27 +50,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
     return True
 
 
-async def handle_webhook(hass: HomeAssistant, webhook_id: str, request: Request):
-    """Handle incoming webhook from Zoom."""
-    try:
-        data = await request.json()
-        status = WEBHOOK_RESPONSE_SCHEMA(data)
-        _LOGGER.debug("Received webhook: %s", json.dumps(status))
-    except:
-        _LOGGER.warning("Received unknown webhook event: %s", await request.text())
-        return
-
-    hass.bus.async_fire(HA_CONNECTIVITY_EVENT, status)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zoom from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     try:
-        implementation = (
-            await config_entry_oauth2_flow.async_get_config_entry_implementation(
-                hass, entry
-            )
+        implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
+            hass, entry
         )
     except ValueError:
         implementation = ZoomOAuth2Implementation(
@@ -89,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             entry.data[CONF_CLIENT_SECRET],
             OAUTH2_AUTHORIZE,
             OAUTH2_TOKEN,
-            entry.data[CONF_WEBHOOK_ID],
+            entry.data[CONF_VERIFICATION_TOKEN],
         )
         OAuth2FlowHandler.async_register_implementation(hass, implementation)
 
@@ -97,16 +73,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
     )
 
-    # Register callback just once for when Zoom event is received.
-    if entry.data[CONF_WEBHOOK_ID] not in hass.data[DOMAIN]:
-        async_register(
-            hass,
-            DOMAIN,
-            entry.data[CONF_NAME],
-            entry.data[CONF_WEBHOOK_ID],
-            handle_webhook,
-        )
-        _LOGGER.debug("webhook registered")
+    hass.http.register_view(ZoomWebhookRequestView(entry.data[CONF_VERIFICATION_TOKEN]))
+
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
@@ -118,8 +86,5 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     hass.data[DOMAIN].pop(entry.entry_id)
-
-    if entry.data[CONF_WEBHOOK_ID] and len(hass.data[DOMAIN]) == 1:
-        async_unregister(hass, entry.data[CONF_WEBHOOK_ID])
 
     return True

--- a/custom_components/zoom_automation/binary_sensor.py
+++ b/custom_components/zoom_automation/binary_sensor.py
@@ -22,11 +22,14 @@ _LOGGER = getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities,
+    hass: HomeAssistantType,
+    config_entry: ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Set up a Zoom Automation presence sensor entry."""
     async_add_entities(
-        [ZoomOccupancySensor(hass, config_entry)], update_before_add=True,
+        [ZoomOccupancySensor(hass, config_entry)],
+        update_before_add=True,
     )
 
 

--- a/custom_components/zoom_automation/binary_sensor.py
+++ b/custom_components/zoom_automation/binary_sensor.py
@@ -22,11 +22,14 @@ _LOGGER = getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities,
+    hass: HomeAssistantType,
+    config_entry: ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Set up a Zoom Automation presence sensor entry."""
     async_add_entities(
-        [ZoomConnectivitySensor(hass, config_entry)], update_before_add=True,
+        [ZoomConnectivitySensor(hass, config_entry)],
+        update_before_add=True,
     )
 
 

--- a/custom_components/zoom_automation/binary_sensor.py
+++ b/custom_components/zoom_automation/binary_sensor.py
@@ -22,14 +22,11 @@ _LOGGER = getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
-    config_entry: ConfigEntry,
-    async_add_entities,
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities,
 ) -> None:
     """Set up a Zoom Automation presence sensor entry."""
     async_add_entities(
-        [ZoomConnectivitySensor(hass, config_entry)],
-        update_before_add=True,
+        [ZoomConnectivitySensor(hass, config_entry)], update_before_add=True,
     )
 
 

--- a/custom_components/zoom_automation/common.py
+++ b/custom_components/zoom_automation/common.py
@@ -27,7 +27,12 @@ class ZoomOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
         """Initialize local auth implementation."""
         self._webhook_id = webhook_id
         super().__init__(
-            hass, domain, client_id, client_secret, authorize_url, token_url,
+            hass,
+            domain,
+            client_id,
+            client_secret,
+            authorize_url,
+            token_url,
         )
 
     @property

--- a/custom_components/zoom_automation/common.py
+++ b/custom_components/zoom_automation/common.py
@@ -27,12 +27,7 @@ class ZoomOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
         """Initialize local auth implementation."""
         self._webhook_id = webhook_id
         super().__init__(
-            hass,
-            domain,
-            client_id,
-            client_secret,
-            authorize_url,
-            token_url,
+            hass, domain, client_id, client_secret, authorize_url, token_url,
         )
 
     @property

--- a/custom_components/zoom_automation/common.py
+++ b/custom_components/zoom_automation/common.py
@@ -40,7 +40,12 @@ class ZoomOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
         """Initialize local auth implementation."""
         self._verification_token = verification_token
         super().__init__(
-            hass, domain, client_id, client_secret, authorize_url, token_url,
+            hass,
+            domain,
+            client_id,
+            client_secret,
+            authorize_url,
+            token_url,
         )
 
     @property

--- a/custom_components/zoom_automation/common.py
+++ b/custom_components/zoom_automation/common.py
@@ -1,6 +1,11 @@
 """Common classes and functions for Zoom Automation."""
+import json
+from logging import getLogger
+
+from aiohttp.web import Request, Response
+from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_WEBHOOK_ID
+from homeassistant.const import CONF_NAME, HTTP_OK
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.entity import Entity
@@ -8,7 +13,15 @@ from homeassistant.helpers.network import get_url
 from homeassistant.util import slugify
 
 from .api import ZoomAPI
-from .const import DEFAULT_NAME, DOMAIN
+from .const import (
+    DEFAULT_NAME,
+    DOMAIN,
+    HA_OCCUPANCY_EVENT,
+    HA_URL,
+    WEBHOOK_RESPONSE_SCHEMA,
+)
+
+_LOGGER = getLogger(__name__)
 
 
 class ZoomOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
@@ -22,17 +35,12 @@ class ZoomOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementatio
         client_secret: str,
         authorize_url: str,
         token_url: str,
-        webhook_id: str,
+        verification_token: str,
     ):
         """Initialize local auth implementation."""
-        self._webhook_id = webhook_id
+        self._verification_token = verification_token
         super().__init__(
-            hass,
-            domain,
-            client_id,
-            client_secret,
-            authorize_url,
-            token_url,
+            hass, domain, client_id, client_secret, authorize_url, token_url,
         )
 
     @property
@@ -60,10 +68,48 @@ class ZoomBaseEntity(Entity):
         self._config_entry = config_entry
         self._hass = hass
         self._api: ZoomAPI = hass.data[DOMAIN][config_entry.entry_id]
-        self._webhook_id: str = config_entry.data[CONF_WEBHOOK_ID]
         self._name: str = config_entry.data[CONF_NAME]
 
     @property
     def unique_id(self):
         """Return unique_id for entity."""
         return f"{DOMAIN}_{slugify(self._name)}"
+
+
+class ZoomWebhookRequestView(HomeAssistantView):
+    """Provide a page for the device to call."""
+
+    requires_auth = False
+    core_allowed = True
+    url = HA_URL
+    name = HA_URL[1:].replace("/", ":")
+
+    def __init__(self, verification_token: str) -> None:
+        """Initialize view."""
+        self._verification_token = verification_token
+
+    async def post(self, request: Request):
+        """Respond to requests from the device."""
+        hass = request.app["hass"]
+        headers = request.headers
+
+        if (
+            "authorization" not in headers
+            or headers["authorization"] != self._verification_token
+        ):
+            _LOGGER.warning(
+                "Unauthorized request received: %s (Headers: %s)",
+                await request.text(),
+                json.dumps(request.headers),
+            )
+            return Response(status=HTTP_OK)
+
+        try:
+            data = await request.json()
+            status = WEBHOOK_RESPONSE_SCHEMA(data)
+            _LOGGER.debug("Received well-formed event: %s", json.dumps(status))
+            hass.bus.async_fire(HA_OCCUPANCY_EVENT, status)
+        except:
+            _LOGGER.warning("Received unknown event: %s", await request.text())
+
+        return Response(status=HTTP_OK)

--- a/custom_components/zoom_automation/config_flow.py
+++ b/custom_components/zoom_automation/config_flow.py
@@ -3,18 +3,20 @@ import logging
 from typing import Any, Dict
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_CLIENT_SECRET,
-    CONF_NAME,
-    CONF_WEBHOOK_ID,
-)
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_NAME
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.util import slugify
 import voluptuous as vol
 
 from .common import ZoomOAuth2Implementation
-from .const import DEFAULT_NAME, DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN, ZOOM_SCHEMA
+from .const import (
+    CONF_VERIFICATION_TOKEN,
+    DEFAULT_NAME,
+    DOMAIN,
+    OAUTH2_AUTHORIZE,
+    OAUTH2_TOKEN,
+    ZOOM_SCHEMA,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class OAuth2FlowHandler(
                 user_input[CONF_CLIENT_SECRET],
                 OAUTH2_AUTHORIZE,
                 OAUTH2_TOKEN,
-                user_input[CONF_WEBHOOK_ID],
+                user_input[CONF_VERIFICATION_TOKEN],
             ),
         )
 
@@ -95,7 +97,7 @@ class OAuth2FlowHandler(
                 CONF_NAME: self._name,
                 CONF_CLIENT_ID: self.flow_impl.client_id,
                 CONF_CLIENT_SECRET: self.flow_impl.client_secret,
-                CONF_WEBHOOK_ID: self.flow_impl._webhook_id,
+                CONF_VERIFICATION_TOKEN: self.flow_impl._verification_token,
             }
         )
         return self.async_create_entry(title=self._name, data=data)

--- a/custom_components/zoom_automation/const.py
+++ b/custom_components/zoom_automation/const.py
@@ -1,10 +1,14 @@
 """Constants for the Zoom Automation integration."""
-from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_WEBHOOK_ID
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
 DOMAIN = "zoom_automation"
 DEFAULT_NAME = "Zoom Automation"
+
+HA_URL = f"/api/{DOMAIN}"
+
+CONF_VERIFICATION_TOKEN = "verification_token"
 
 OAUTH2_AUTHORIZE = "https://zoom.us/oauth/authorize"
 OAUTH2_TOKEN = "https://zoom.us/oauth/token"
@@ -16,7 +20,7 @@ ZOOM_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CLIENT_ID): vol.Coerce(str),
         vol.Required(CONF_CLIENT_SECRET): vol.Coerce(str),
-        vol.Required(CONF_WEBHOOK_ID): vol.Coerce(str),
+        vol.Required(CONF_VERIFICATION_TOKEN): vol.Coerce(str),
     }
 )
 
@@ -26,12 +30,12 @@ ATTR_OBJECT = "object"
 ATTR_ID = "id"
 ATTR_PRESENCE_STATUS = "presence_status"
 
-CONNECTIVITY_EVENT = "user.presence_status_updated"
-CONNECTIVITY_STATUS = [ATTR_PAYLOAD, ATTR_OBJECT, ATTR_PRESENCE_STATUS]
-CONNECTIVITY_ID = [ATTR_PAYLOAD, ATTR_OBJECT, ATTR_ID]
-CONNECTIVITY_STATUS_OFF = "Available"
+OCCUPANCY_EVENT = "user.presence_status_updated"
+OCCUPANCY_STATUS = [ATTR_PAYLOAD, ATTR_OBJECT, ATTR_PRESENCE_STATUS]
+OCCUPANCY_ID = [ATTR_PAYLOAD, ATTR_OBJECT, ATTR_ID]
+OCCUPANCY_STATUS_OFF = "Available"
 
-HA_CONNECTIVITY_EVENT = f"{DOMAIN}_webhook"
+HA_OCCUPANCY_EVENT = f"{DOMAIN}_webhook"
 
 WEBHOOK_RESPONSE_SCHEMA = vol.Schema(
     {vol.Required(ATTR_EVENT): cv.string, vol.Required(ATTR_PAYLOAD): dict}

--- a/custom_components/zoom_automation/manifest.json
+++ b/custom_components/zoom_automation/manifest.json
@@ -6,5 +6,6 @@
   "issue_tracker": "https://github.com/raman325/ha-zoom_automation/issues",
   "codeowners": [
     "@raman325"
-  ]
+  ],
+  "dependencies": ["http"]
 }

--- a/custom_components/zoom_automation/sensor.py
+++ b/custom_components/zoom_automation/sensor.py
@@ -11,9 +11,7 @@ SCAN_INTERVAL = timedelta(hours=1)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
-    config_entry: ConfigEntry,
-    async_add_entities,
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities,
 ) -> None:
     """Set up a Zoom Automation profile sensor entry."""
     async_add_entities([ZoomProfileSensor(hass, config_entry)], update_before_add=True)

--- a/custom_components/zoom_automation/sensor.py
+++ b/custom_components/zoom_automation/sensor.py
@@ -11,7 +11,9 @@ SCAN_INTERVAL = timedelta(hours=1)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities,
+    hass: HomeAssistantType,
+    config_entry: ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Set up a Zoom Automation profile sensor entry."""
     async_add_entities([ZoomProfileSensor(hass, config_entry)], update_before_add=True)

--- a/custom_components/zoom_automation/strings.json
+++ b/custom_components/zoom_automation/strings.json
@@ -7,7 +7,7 @@
         "data": {
           "client_id": "Client ID (obtained from Zoom app)",
           "client_secret": "Client Secret (obtained from Zoom app)",
-          "webhook_id": "Webhook ID (configured in the Event Subscriptions section of creating your Zoom app)"
+          "verification_token": "Verification Token (obtained from the Features section of custom Zoom app)"
         }
       },
       "choose_name": {

--- a/custom_components/zoom_automation/translations/en.json
+++ b/custom_components/zoom_automation/translations/en.json
@@ -7,7 +7,7 @@
         "data": {
           "client_id": "Client ID (obtained from Zoom app)",
           "client_secret": "Client Secret (obtained from Zoom app)",
-          "webhook_id": "Webhook ID (configured in the Event Subscriptions section of creating your Zoom app)"
+          "verification_token": "Verification Token (obtained from the Features section of custom Zoom app)"
         }
       },
       "choose_name": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "Zoom Automation",
     "hacs": "0.24.0",
-    "domains": [],
+    "domains": ["binary_sensor", "sensor"],
     "iot_class": "Cloud Push",
     "render_readme": true,
     "homeassistant": "0.110.0"

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,7 @@
     "name": "Zoom Automation",
     "hacs": "0.24.0",
     "domains": ["binary_sensor", "sensor"],
+    "zip_release": true,
     "iot_class": "Cloud Push",
     "render_readme": true,
     "homeassistant": "0.110.0"


### PR DESCRIPTION
Using the webhook component prevented me from being able to validate the request and required more work for the user to generate a good webhook ID. This breaking change requires the user to include a `verification token` which will ensure that only Zoom is sending notifications to this new endpoint