### PR TITLE
Improve handling of invalid tokens

### DIFF
--- a/custom_components/zoom/__init__.py
+++ b/custom_components/zoom/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         my_profile = await api.async_get_my_user_profile()
     except (HTTPUnauthorized, ClientResponseError) as err:
-        if isinstance(err, ClientResponseError) and err.status != 401:
+        if isinstance(err, ClientResponseError) and err.status != 401 and err.status != 400:
             return False
 
         # If we are not authorized, we need to revalidate OAuth

--- a/custom_components/zoom/__init__.py
+++ b/custom_components/zoom/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         my_profile = await api.async_get_my_user_profile()
     except (HTTPUnauthorized, ClientResponseError) as err:
-        if isinstance(err, ClientResponseError) and err.status != 401 and err.status != 400:
+        if isinstance(err, ClientResponseError) and err.status not in (400, 401):
             return False
 
         # If we are not authorized, we need to revalidate OAuth

--- a/custom_components/zoom/common.py
+++ b/custom_components/zoom/common.py
@@ -149,8 +149,8 @@ class ZoomUserProfileDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             return await self._api.async_get_my_user_profile()
-        except:
-            raise UpdateFailed
+        except Exception as err:
+            raise UpdateFailed(err)
 
 
 class ZoomContactListDataUpdateCoordinator(DataUpdateCoordinator):
@@ -174,5 +174,5 @@ class ZoomContactListDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             return await self._api.async_get_contacts(self._contact_types)
-        except:
-            raise UpdateFailed
+        except Exception as err:
+            raise UpdateFailed(err)

--- a/custom_components/zoom/common.py
+++ b/custom_components/zoom/common.py
@@ -150,7 +150,7 @@ class ZoomUserProfileDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             return await self._api.async_get_my_user_profile()
         except Exception as err:
-            raise UpdateFailed(err)
+            raise UpdateFailed from err
 
 
 class ZoomContactListDataUpdateCoordinator(DataUpdateCoordinator):
@@ -175,4 +175,4 @@ class ZoomContactListDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             return await self._api.async_get_contacts(self._contact_types)
         except Exception as err:
-            raise UpdateFailed(err)
+            raise UpdateFailed from err


### PR DESCRIPTION
This integration is currently failing for me due to an invalid grant. Handle this in `async_setup_entry` so that reauth is triggered.

```
DEBUG (MainThread) [homeassistant.helpers.config_entry_oauth2_flow] Token request failed with status=400, body={"reason":"Invalid Token!","error":"invalid_grant"}
```