### PR TITLE
Use the new API - async_forward_entry_setups

### DIFF
--- a/custom_components/zoom/__init__.py
+++ b/custom_components/zoom/__init__.py
@@ -143,10 +143,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Register view
     hass.http.register_view(ZoomWebhookRequestView())
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    # Forward config entry setups for all defined platforms
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
This PR updates the Zoom custom component to be compatible with recent versions of Home Assistant.

Home Assistant removed the async_forward_entry_setup method in favor of async_forward_entry_setups (plural).
This caused the integration to fail to load with the following error:
```
AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
```
**Changes**
Replaced deprecated `hass.config_entries.async_forward_entry_setup(entry, platform)` calls with:

`await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)`
Removed the per-platform loop since the new API accepts a list of platforms.

**Testing**
Verified that Home Assistant no longer raises an AttributeError during startup.
Integration now loads correctly under Home Assistant 2025.9+.