### PR TITLE
Pre-create validation event entity and restore existing entities on startup

### DIFF
--- a/tests/const.py
+++ b/tests/const.py
@@ -1,12 +1,25 @@
-"""Constants for zoom tests."""
+"""Constants and helpers for zoom tests."""
 
 from datetime import timedelta
 
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_NAME
+from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.zoom.const import CONF_SECRET_TOKEN, DOMAIN
+from custom_components.zoom.const import CONF_SECRET_TOKEN, DOMAIN, VALIDATION_EVENT
+
+
+def get_non_validation_event_entities(
+    ent_reg: er.EntityRegistry, entry_id: str
+) -> list[er.RegistryEntry]:
+    """Get event entities excluding the pre-created validation entity."""
+    return [
+        e
+        for e in er.async_entries_for_config_entry(ent_reg, entry_id)
+        if e.domain == EVENT_DOMAIN and VALIDATION_EVENT not in e.unique_id
+    ]
 
 MOCK_CONFIG = {
     CONF_NAME: "test",


### PR DESCRIPTION
## Summary
- Pre-creates the `endpoint.url_validation` event entity (disabled by default) since Zoom sends this event every 72 hours for endpoint revalidation
- Recreates existing event entities from the registry on startup to properly restore state and attributes
- Updates tests to account for the pre-created validation entity

## Details
The validation event entity is now created immediately on integration setup rather than waiting for the first validation webhook. Since we know this event will always occur (Zoom requires it), pre-creating it provides:
- Better discoverability in the entity registry
- Proper state restoration on HA restart
- Consistent behavior with other event entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)